### PR TITLE
Fix typo on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Our flag value is the part right of the `Cookie: ` bit.
 - Just run the tool from `run.py`, providing `Client ID` and `Secret` when asked, then wait for it:
 
   ```bash
-  python migrator.py --mmr_cookie="<session cookie on a string>"
+  python migrator.py --mmr-cookie="<session cookie on a string>"
   ```
 
 Once the script is triggered, it'll request all of your workouts one by one as per the CSV file and download them to a folder called outputs.


### PR DESCRIPTION
# Changelog

- `--mmr-cookie` flaw was referenced as `--mmr_cookie` instead on readme. 

https://github.com/Korrd/mapmyfitness-to-strava-migrator/pull/11